### PR TITLE
Fix id attr value not being interpolated for leafletDirectiveMap events

### DIFF
--- a/src/services/events/leafletMapEvents.js
+++ b/src/services/events/leafletMapEvents.js
@@ -84,7 +84,7 @@ angular.module('ui-leaflet')
         leafletIterators.each(mapEvents, function(eventName) {
             var context = {};
             context[contextName] = eventName;
-            map.on(eventName, _genDispatchMapEvent(scope, eventName, logic, map._container.id || ''), context);
+            map.on(eventName, _genDispatchMapEvent(scope, eventName, logic, scope.mapId || ''), context);
         });
     };
 


### PR DESCRIPTION
Fixex id attribute value not being interpolated for leafletDirectiveMap events.

Cf. Issue #235.