### PR TITLE
$timout to setTimeout in _modelChangeInDirective()

### DIFF
--- a/src/services/leafletHelpers.js
+++ b/src/services/leafletHelpers.js
@@ -145,7 +145,7 @@ angular.module('ui-leaflet').service('leafletHelpers', function ($q, $log, $time
 
         trapObj[trapField] = true;
         let ret = cbToExec();
-        $timeout(()=> {
+        setTimeout(()=> {
             trapObj[trapField] = false;
         }, _watchTrapDelayMilliSec);
         return ret;


### PR DESCRIPTION
Changed $timeout to setTimeout in _modelChangeInDirective function to avoid angular overhead creating a new defer for each marker, when all that is required is a simple delay in execution. The $timeout is not noticeable in Chrome and Firefox however causes substantial freeze/lock in Internet Explorer and Edge after creating new markers.

*Note: I don't think the 10 ms delay is required, 0 is a enough, due to the fact that setTimeout queues the execution to occur after the current. However I don't want to cause any new issues, because this solution seems hacky enough.*