### PR TITLE
Don't delete all map defaults on one map destroy

### DIFF
--- a/src/directives/leaflet.js
+++ b/src/directives/leaflet.js
@@ -135,7 +135,7 @@ angular.module('ui-leaflet', ['nemLogging']).directive('leaflet',
             });
 
             scope.$on('$destroy', function () {
-                leafletMapDefaults.reset();
+                leafletMapDefaults.reset(attrs.id);
                 map.remove();
                 leafletData.unresolveMap(attrs.id);
             });

--- a/src/services/leafletMapDefaults.js
+++ b/src/services/leafletMapDefaults.js
@@ -47,8 +47,9 @@ angular.module('ui-leaflet').factory('leafletMapDefaults', function ($q, leaflet
 
     // Get the _defaults dictionary, and override the properties defined by the user
     return {
-        reset: function () {
-           defaults = {};
+        reset: function (scopeId) {
+            var mapId = obtainEffectiveMapId(defaults, scopeId);
+            delete defaults[mapId];
         },
         getDefaults: function (scopeId) {
             var mapId = obtainEffectiveMapId(defaults, scopeId);


### PR DESCRIPTION
Instead of resetting all the map defaults, only reset the defaults for the map that is being destroyed.

I had an issue where one map was deleted, and the layer control disappeared from a different map.

This also applies to the master branch.